### PR TITLE
Add basic Module Federation setup

### DIFF
--- a/container/package.json
+++ b/container/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "container",
+  "version": "1.0.0",
+  "private": true,
+  "scripts": {
+    "build": "webpack --config webpack.config.js"
+  }
+}

--- a/container/src/bootstrap.js
+++ b/container/src/bootstrap.js
@@ -1,0 +1,1 @@
+console.log('bootstrap');

--- a/container/src/index.html
+++ b/container/src/index.html
@@ -1,0 +1,1 @@
+<html><body><div id='root'></div></body></html>

--- a/container/src/index.js
+++ b/container/src/index.js
@@ -1,0 +1,1 @@
+import('./bootstrap');

--- a/container/webpack.config.js
+++ b/container/webpack.config.js
@@ -1,0 +1,26 @@
+const HtmlWebpackPlugin = require('html-webpack-plugin');
+const { ModuleFederationPlugin } = require('webpack').container;
+const path = require('path');
+
+module.exports = {
+  entry: './src/index.js',
+  mode: 'development',
+  output: {
+    path: path.resolve(__dirname, 'dist'),
+    publicPath: 'auto'
+  },
+  devServer: {
+    port: 8080
+  },
+  plugins: [
+    new ModuleFederationPlugin({
+      name: 'container',
+      remotes: {
+        mfeReact: 'mfeReact@http://localhost:8081/remoteEntry.js',
+        mfeAngular: 'mfeAngular@http://localhost:8082/remoteEntry.js',
+        mfeVue: 'mfeVue@http://localhost:8083/remoteEntry.js'
+      }
+    }),
+    new HtmlWebpackPlugin({ template: './src/index.html' })
+  ]
+};

--- a/mfe-angular/package.json
+++ b/mfe-angular/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "mfe-angular",
+  "version": "1.0.0",
+  "private": true,
+  "scripts": {
+    "build": "webpack --config webpack.config.js"
+  }
+}

--- a/mfe-angular/src/App.js
+++ b/mfe-angular/src/App.js
@@ -1,0 +1,1 @@
+export default () => 'Angular App';

--- a/mfe-angular/src/index.js
+++ b/mfe-angular/src/index.js
@@ -1,0 +1,1 @@
+import App from './App';console.log(App());

--- a/mfe-angular/webpack.config.js
+++ b/mfe-angular/webpack.config.js
@@ -1,0 +1,23 @@
+const { ModuleFederationPlugin } = require('webpack').container;
+const path = require('path');
+
+module.exports = {
+  entry: './src/index.js',
+  mode: 'development',
+  output: {
+    path: path.resolve(__dirname, 'dist'),
+    publicPath: 'auto'
+  },
+  devServer: {
+    port: 8082
+  },
+  plugins: [
+    new ModuleFederationPlugin({
+      name: 'mfeAngular',
+      filename: 'remoteEntry.js',
+      exposes: {
+        './App': './src/App'
+      }
+    })
+  ]
+};

--- a/mfe-react/package.json
+++ b/mfe-react/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "mfe-react",
+  "version": "1.0.0",
+  "private": true,
+  "scripts": {
+    "build": "webpack --config webpack.config.js"
+  }
+}

--- a/mfe-react/src/App.js
+++ b/mfe-react/src/App.js
@@ -1,0 +1,1 @@
+export default () => 'React App';

--- a/mfe-react/src/index.js
+++ b/mfe-react/src/index.js
@@ -1,0 +1,1 @@
+import App from './App';console.log(App());

--- a/mfe-react/webpack.config.js
+++ b/mfe-react/webpack.config.js
@@ -1,0 +1,23 @@
+const { ModuleFederationPlugin } = require('webpack').container;
+const path = require('path');
+
+module.exports = {
+  entry: './src/index.js',
+  mode: 'development',
+  output: {
+    path: path.resolve(__dirname, 'dist'),
+    publicPath: 'auto'
+  },
+  devServer: {
+    port: 8081
+  },
+  plugins: [
+    new ModuleFederationPlugin({
+      name: 'mfeReact',
+      filename: 'remoteEntry.js',
+      exposes: {
+        './App': './src/App'
+      }
+    })
+  ]
+};

--- a/mfe-vue/package.json
+++ b/mfe-vue/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "mfe-vue",
+  "version": "1.0.0",
+  "private": true,
+  "scripts": {
+    "build": "webpack --config webpack.config.js"
+  }
+}

--- a/mfe-vue/src/App.js
+++ b/mfe-vue/src/App.js
@@ -1,0 +1,1 @@
+export default () => 'Vue App';

--- a/mfe-vue/src/index.js
+++ b/mfe-vue/src/index.js
@@ -1,0 +1,1 @@
+import App from './App';console.log(App());

--- a/mfe-vue/webpack.config.js
+++ b/mfe-vue/webpack.config.js
@@ -1,0 +1,23 @@
+const { ModuleFederationPlugin } = require('webpack').container;
+const path = require('path');
+
+module.exports = {
+  entry: './src/index.js',
+  mode: 'development',
+  output: {
+    path: path.resolve(__dirname, 'dist'),
+    publicPath: 'auto'
+  },
+  devServer: {
+    port: 8083
+  },
+  plugins: [
+    new ModuleFederationPlugin({
+      name: 'mfeVue',
+      filename: 'remoteEntry.js',
+      exposes: {
+        './App': './src/App'
+      }
+    })
+  ]
+};


### PR DESCRIPTION
## Summary
- scaffold container and MFEs
- configure Module Federation for container and remote apps
- add build scripts using the new webpack configs

## Testing
- `npm run build` *(fails: webpack not found)*

------
https://chatgpt.com/codex/tasks/task_e_684a95ca74848331ab8429886e8ce3ec